### PR TITLE
removed mention of the patch__default() method from patch() documentation

### DIFF
--- a/nested_diff/__init__.py
+++ b/nested_diff/__init__.py
@@ -462,8 +462,7 @@ class Patcher(object):
         Return patched object.
 
         This method is a dispatcher and calls apropriate patch method for
-        target value according to it's type. Values with non-registered types
-        patched by `patch__default` method.
+        target value according to it's type.
 
         :param target: Object to patch.
         :param ndiff: Nested diff.


### PR DESCRIPTION
Hello @mr-mixas 👋

I noticed the `patch()` method on the `Patcher` class mentions a `patch_default()` method that doesn't exist.