### PR TITLE
made patch_set() an instance method

### DIFF
--- a/nested_diff/__init__.py
+++ b/nested_diff/__init__.py
@@ -567,8 +567,7 @@ class Patcher(object):
 
         return '\n'.join(target)
 
-    @staticmethod
-    def patch_set(target, ndiff):
+    def patch_set(self, target, ndiff):
         """
         Return patched set.
 


### PR DESCRIPTION
This helps when subclassing Patcher and writing stateful patchers that need to memoize the context before taking patching decisions